### PR TITLE
Provide longitude and latitude for seed Posts

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -26,7 +26,9 @@ number_of_fake_posts.times do |i|
     expiration: Time.current.utc + 2.weeks,
     validation: SecureRandom.hex,
     show: true,
-    accuracy: 2000
+    accuracy: 2000,
+    latitude: rand(35..45),
+    longitude: rand(-120..-80)
   )
 
   puts "Created #{(i + 1).ordinalize} fake Post (out of #{number_of_fake_posts})."
@@ -48,7 +50,9 @@ Post.create!(
   expiration: Time.current.utc - 1.week,
   validation: SecureRandom.hex,
   show: true,
-  accuracy: 2000
+  accuracy: 2000,
+  latitude: rand(35..45),
+  longitude: rand(-120..-80)
 )
 puts "Created expired  posts"
 
@@ -68,7 +72,9 @@ Post.create!(
   expiration: Time.current.utc + 2.weeks,
   validation: SecureRandom.hex,
   show: false,
-  accuracy: 2000
+  accuracy: 2000,
+  latitude: rand(35..45),
+  longitude: rand(-120..-80)
 )
 puts "Created unconfirmed posts"
 


### PR DESCRIPTION
The seed posts are created using the Faker gem, which makes up addresses. The geocoder can't find these fake places, so it doesn't set longitude or latitude for them. This was causing an error on `posts#show`, since it assumes they're not nil. To get around this issue, this PR manually passes random longitude and latitudes in.

This leads to a weird problem, where an address could be in Florida, but the map would show Oregon.

The specific range I used is roughly the interior of the US ( we don't have points in the water, or in other countries yet).

We should consider moving off the Faker gem, and using real addresses instead. Maybe Post office addresses?
