### PR TITLE
Fix post types

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -8,7 +8,7 @@ class PostsController < ApplicationController
   end
 
   def new
-    @post = Post.new
+    @post = Post.new(post_type: "needed")
   end
 
   def create
@@ -37,7 +37,7 @@ class PostsController < ApplicationController
 
     @post = Post.find_by_validation(params[:validation])
 
-    if @post.update_attributes(post_params.merge(post_type: post_params[:post_type].to_i))
+    if @post.update_attributes(post_params)
       redirect_to @post
     else
       render action: "edit"

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -68,7 +68,6 @@ class Post < ActiveRecord::Base
 
   def self.create_default_params(init_params)
     init_params[:expiration] = (Time.current.utc + 1.day).iso8601
-    init_params[:post_type] = init_params[:post_type].to_i
     init_params[:validation] = generate_validation
     init_params
   end

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -3,24 +3,17 @@
   <%= render "posts/form_error", :target => @post %>
 
   <div class="button-group">
-    <label>
-      <%=
-        f.radio_button(
-          :post_type,
-          :needed,
-          checked: true
-        )
-      %>
-      <span class="button-group-item">Needed</span>
-    </label><label>
-      <%=
-        f.radio_button(
-          :post_type,
-          :available
-        )
-      %>
-      <span class="button-group-item">Available</span>
-    </label>
+    <% Post.post_types.keys.each do |post_type_name| %>
+      <label>
+        <%=
+          f.radio_button(
+            :post_type,
+            post_type_name
+          )
+        %>
+        <span class="button-group-item"><%= post_type_name.humanize %></span>
+      </label>
+    <% end %>
   </div>
 
   <p></p>

--- a/spec/features/post_spec.rb
+++ b/spec/features/post_spec.rb
@@ -9,7 +9,7 @@ describe "the search process", type: :feature do
 
     visit root_url
     fill_in "location", with: "Berkeley"
-    choose :type_needed
+    choose "Needed"
     click_button "Search"
 
     expect(page).to have_content post.title
@@ -65,10 +65,18 @@ describe "the post submission process" do
     expect(page).to have_content("confirmation")
   end
 
+  it "submits a new default post which should be 'needed'" do
+    visit new_post_url
+    fill_in_post_form
+    click_button "Create Post"
+
+    expect(Post.last.post_type).to eq("needed")
+  end
+
   it "submits a new 'available' post with success" do
     visit new_post_url
     fill_in_post_form
-    choose :post_post_type_available
+    choose "Available"
     click_button "Create Post"
 
     expect(page).to have_content("confirmation")

--- a/spec/features/post_spec.rb
+++ b/spec/features/post_spec.rb
@@ -57,12 +57,22 @@ describe "the post submission process" do
     expect(page).to have_content("Submit a New Post")
   end
 
-  it "submits a new post with success" do
+  it "submits a new 'needed' post with success" do
     visit new_post_url
     fill_in_post_form
     click_button "Create Post"
 
     expect(page).to have_content("confirmation")
+  end
+
+  it "submits a new 'available' post with success" do
+    visit new_post_url
+    fill_in_post_form
+    choose :post_post_type_available
+    click_button "Create Post"
+
+    expect(page).to have_content("confirmation")
+    expect(Post.last.post_type).to eq("available")
   end
 
   it "invalidates blank fields" do

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -88,11 +88,5 @@ describe Post do
 
       expect(params).to include(:expiration)
     end
-
-    it "converts post type to int" do
-      params = Post.create_default_params(post_type: "1")
-
-      expect(params).to include(post_type: 1)
-    end
   end
 end

--- a/spec/support/features/post_helpers.rb
+++ b/spec/support/features/post_helpers.rb
@@ -1,5 +1,5 @@
 def fill_in_post_form
-  choose :post_post_type_needed
+  choose "Needed"
   fill_in "Title", with: "I need housing"
   fill_in "Email", with: "foo@bar.com"
   fill_in "Email confirmation", with: "foo@bar.com"


### PR DESCRIPTION
Fixes #19.

The issue was we were submitting the _value_ of the `post_type` enum, rather than the _key_, and changing the form params from string to integers. Rails handles the magic for us. :train: :gem:  :crystal_ball:

This also helps clean up some code: net **-4** lines of code, though I added two spec cases :D 
