### PR TITLE
Add `rounded_` methods for longitude and latitude

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -57,6 +57,14 @@ class Post < ActiveRecord::Base
     [street, city, state, postal_code, country].compact.join(", ")
   end
 
+  def rounded_latitude
+    latitude.try(:round, 2)
+  end
+
+  def rounded_longitude
+    longitude.try(:round, 2)
+  end
+
   def self.generate_validation
     require "securerandom"
     # a collision here has low probability, but might as well check

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -26,8 +26,8 @@
 
 <div id="map"
      class="map"
-     data-latitude="<%= @post.latitude.round(2) %>"
-     data-longitude="<%= @post.longitude.round(2) %>"
+     data-latitude="<%= @post.rounded_latitude %>"
+     data-longitude="<%= @post.rounded_longitude %>"
      data-accuracy="<%= @post.accuracy %>">
   <%# Filled in via JS with leaflet %>
   <%# TODO: we should fix this rounding so that it's actually more rounded

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -87,4 +87,22 @@ describe Post do
       expect(params).to include(:expiration)
     end
   end
+
+  describe ".rounded_latitude" do
+    it "rounds to two places" do
+      post = create(:post, city: "Berkeley", state: "CA", show: true)
+      post.latitude = 0.12345
+
+      expect(post.rounded_latitude).to eq 0.12
+    end
+  end
+
+  describe ".rounded_longitude" do
+    it "rounds to two places" do
+      post = create(:post, city: "Berkeley", state: "CA", show: true)
+      post.longitude = 0.98765
+
+      expect(post.rounded_longitude).to eq 0.99
+    end
+  end
 end


### PR DESCRIPTION
In dev, since we have fake addresses, the geolocator can't give posts a `latitude` or `longitude`, which makes the `show` page have a NilClass exception.

This PR fixes that, and moves the logic of how to round to the model, where it belongs.
