### PR TITLE
Add overcommit w/ configs for Rubocop and ScssLint

### DIFF
--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -1,0 +1,36 @@
+# Use this file to configure the Overcommit hooks you wish to use. This will
+# extend the default configuration defined in:
+# https://github.com/brigade/overcommit/blob/master/config/default.yml
+#
+# At the topmost level of this YAML file is a key representing type of hook
+# being run (e.g. pre-commit, commit-msg, etc.). Within each type you can
+# customize each hook, such as whether to only run it on certain files (via
+# `include`), whether to only display output if it fails (via `quiet`), etc.
+#
+# For a complete list of hooks, see:
+# https://github.com/brigade/overcommit/tree/master/lib/overcommit/hook
+#
+# For a complete list of options that you can use to customize hooks, see:
+# https://github.com/brigade/overcommit#configuration
+#
+# Uncomment the following lines to make the configuration take effect.
+
+PreCommit:
+  RuboCop:
+    enabled: true
+    on_warn: fail # Treat all warnings as failures
+
+  TrailingWhitespace:
+    enabled: true
+    exclude:
+      - '**/db/structure.sql' # Ignore trailing whitespace in generated files
+
+  ScssLint:
+    enabled: true
+
+#PostCheckout:
+#  ALL: # Special hook name that customizes all hooks of this type
+#    quiet: true # Change post-checkout hooks to only display output on failure
+#
+#  IndexTags:
+#    enabled: true # Generate a tags file with `ctags` each time HEAD changes

--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,8 @@ group :development, :test do
   gem "web-console", "~> 2.0"
   gem "letter_opener"
   gem "faker"
+  gem "rubocop", "~> 0.30.1"
+  gem "overcommit"
 end
 
 group :test do
@@ -44,6 +46,5 @@ group :test do
   gem "simplecov", require: false
   gem "factory_girl_rails", "~> 4.5.0"
   gem "rspec-rails", "~> 3.2.1"
-  gem "rubocop", "~> 0.30.1"
   gem "scss_lint", "~> 0.39.0", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,8 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    childprocess (0.5.8)
+      ffi (~> 1.0, >= 1.0.11)
     coffee-rails (4.1.0)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
@@ -105,6 +107,7 @@ GEM
       railties (>= 3.0.0)
     faker (1.5.0)
       i18n (~> 0.5)
+    ffi (1.9.10)
     formtastic (3.1.3)
       actionpack (>= 3.2.13)
     formtastic_i18n (0.4.1)
@@ -121,6 +124,7 @@ GEM
       has_scope (~> 0.6.0.rc)
       railties (>= 3.2, < 5)
       responders
+    iniparse (1.4.1)
     jquery-rails (4.0.5)
       rails-dom-testing (~> 1.0)
       railties (>= 4.2.0)
@@ -152,6 +156,9 @@ GEM
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     orm_adapter (0.5.0)
+    overcommit (0.29.1)
+      childprocess (~> 0.5.6)
+      iniparse (~> 1.4)
     parser (2.2.2.6)
       ast (>= 1.1, < 3.0)
     pg (0.18.3)
@@ -294,6 +301,7 @@ DEPENDENCIES
   letter_opener
   mail_form (~> 1.5.1)
   neat (~> 1.7.2)
+  overcommit
   pg
   pg_search
   rails (~> 4.2.4)
@@ -309,4 +317,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.10.5
+   1.10.6


### PR DESCRIPTION
Running `rake test` runs the specs, as well as Rubocop and ScssLint. I'd always do just `rake` which only does the specs. I thought of changing the default task to run them all, but that might get annoying when you're developing and running tests. 
So I found a gem called 'overcommit' which manages git hooks. I've added pre-commit hooks for Rubocop 

There are also a couple of built-in hooks enabled:
- `TrailingWhitespace` ensures there's no whitespace at the end of any line
- `CommitMsg` has [a few enabled by default](https://github.com/brigade/overcommit#commitmsg) (the ones with the asterisks) If they get to be bothersome, we can disabled them.

Here's what the output looked like, when I made the commit in this PR:

![screen shot 2015-11-23 at 09 32 08](https://cloud.githubusercontent.com/assets/632942/11342533/1ee1f47c-91c5-11e5-9518-4b1156aae062.png) 

Pretty nice looking, I think :)
